### PR TITLE
Bl edit events

### DIFF
--- a/src/scripts/events/Event.js
+++ b/src/scripts/events/Event.js
@@ -1,14 +1,19 @@
+import { EventEditForm } from './EventEditForm.js'
 import { deleteEvent } from './EventsProvider.js'
 
 //creates html for a given event
 export const Event = (event) => {
     return `
-        <div id="${event.startDate}--${event.id}" class="event-card">
+        <div id="${event.startDate}--${event.id}" class="event-card event-card-${event.id}">
             <h3>${event.name}</h3>
             <div>Date: ${event.startDate}</div>
             <div>Location: ${event.eventCity}, ${event.eventState}</div>
             <button type="button" id="delete-event-${event.id}">Delete</button>
+            <button type="button" id="edit-event-${event.id}">Edit</button>
         </div>
+        <form id="event-edit-form-${event.id}" class="event-edit-form no-display">
+            ${EventEditForm(event)}
+        </form>
     `
 }
 
@@ -23,16 +28,52 @@ eventHub.addEventListener('click', event => {
     }
     //check if the weather button was clickded
     else if(event.target.id.startsWith("event-weather-btn-")){
-        //toggle between the hidden class for the weather component
+        //toggle between the no-display class for the weather component
         const [prefix, wather, btn, eventId] = event.target.id.split("-")
         const eventWeatherHTML = document.querySelector(`#event-weather-${eventId}`)
-        if(eventWeatherHTML.classList.contains('hidden')){
-            eventWeatherHTML.classList.remove('hidden')
+        if(eventWeatherHTML.classList.contains('no-display')){
+            eventWeatherHTML.classList.remove('no-display')
             event.target.innerHTML = "Hide Weather"
         }
         else{
-            eventWeatherHTML.classList.add('hidden')
+            eventWeatherHTML.classList.add('no-display')
             event.target.innerHTML = "Show Weather"
         }
+    }
+    //check if edit button was clicked
+    else if(event.target.id.startsWith("edit-event-")){
+        //get event id
+        const [edit, eventPrefix, eventId] = event.target.id.split('-')
+        //get event card element and event edit form
+        const eventCard = document.querySelector(`.event-card-${eventId}`)
+        const editForm = document.querySelector(`#event-edit-form-${eventId}`)
+
+        //hide all other edit event forms that are not already hidden
+        const allEditForms = document.getElementsByClassName('event-edit-form')
+        for(var i = 0; i < allEditForms.length; i++){
+            if(allEditForms[i].id != editForm.id && !(allEditForms[i].classList.contains('no-display'))){
+                allEditForms[i].classList.add('no-display')
+            }
+        }
+
+        //make sure all other event cards are showing
+        const allEventCards = document.getElementsByClassName('event-card')
+        for(var i = 0; i < allEventCards.length; i++){
+            if(allEventCards[i].id != editForm.id && allEventCards[i].classList.contains('no-display')){
+                allEventCards[i].classList.remove('no-display')
+            }
+        }
+
+        //either hide the event card or the event form
+        if(editForm.classList.contains('no-display')){
+            editForm.classList.remove('no-display')
+            eventCard.classList.add('no-display')
+        }
+        else{
+            editForm.classList.add('no-display')
+            eventCard.classList.remove('no-display')
+        }
+
+        
     }
 })

--- a/src/scripts/events/Event.js
+++ b/src/scripts/events/Event.js
@@ -5,14 +5,13 @@ import { deleteEvent } from './EventsProvider.js'
 export const Event = (event) => {
     return `
         <div id="${event.startDate}--${event.id}" class="event-card event-card-${event.id}">
-            <h3>${event.name}</h3>
-            <div>Date: ${event.startDate}</div>
-            <div>Location: ${event.eventCity}, ${event.eventState}</div>
+            <h3 id="event-name-${event.id}">${event.name}</h3>
+            <div id="event-date-${event.id}">Date: ${event.startDate}</div>
+            <div id="event-location-${event.id}">Location: ${event.eventCity}, ${event.eventState} ${event.eventZip}</div>
             <button type="button" id="delete-event-${event.id}">Delete</button>
             <button type="button" id="edit-event-${event.id}">Edit</button>
         </div>
         <form id="event-edit-form-${event.id}" class="event-edit-form no-display">
-            ${EventEditForm(event)}
         </form>
     `
 }
@@ -66,6 +65,9 @@ eventHub.addEventListener('click', event => {
 
         //either hide the event card or the event form
         if(editForm.classList.contains('no-display')){
+            //render the actual form with default vaules
+            editForm.innerHTML = EventEditForm(eventId)
+            //display the form and hide the event card
             editForm.classList.remove('no-display')
             eventCard.classList.add('no-display')
         }

--- a/src/scripts/events/EventEditForm.js
+++ b/src/scripts/events/EventEditForm.js
@@ -1,20 +1,28 @@
 import { editEvent } from './EventsProvider.js'
 
 //render the event edit form
-export const EventEditForm = (event) => {
+export const EventEditForm = (eventId) => {
+
+    //grab all the default values for the form
+    const name = document.querySelector(`#event-name-${eventId}`).innerHTML
+    const date = document.querySelector(`#event-date-${eventId}`).innerHTML.split(" ")[1]
+    const [prefix, cityComma, state, zip] = document.querySelector(`#event-location-${eventId}`).innerHTML.split(" ")
+    const city = cityComma.split(",")[0]
+
+    //return the html for the event edit form
     return `
         <label for="title">Title:</label><br>
-        <input type="text" id="event-edit-form-title-${event.id}" name="title" value="${event.name}"><br>
+        <input type="text" id="event-edit-form-title-${eventId}" name="title" value="${name}"><br>
         <label for="date">Date:</label><br>
-        <input type="date" id="event-edit-form-date-${event.id}" name="date" value="${event.startDate}"><br>
+        <input type="date" id="event-edit-form-date-${eventId}" name="date" value="${date}"><br>
         <label for="city">City:</label><br>
-        <input type="text" id="event-edit-form-city-${event.id}" name="city" value="${event.eventCity}"><br>
+        <input type="text" id="event-edit-form-city-${eventId}" name="city" value="${city}"><br>
         <label for="state">State:</label><br>
-        <input type="text" id="event-edit-form-state-${event.id}" name="state" value="${event.eventState}"><br>
+        <input type="text" id="event-edit-form-state-${eventId}" name="state" value="${state}"><br>
         <label for="zip">Zipcode:</label><br>
-        <input type="text" id="event-edit-form-zip-${event.id}" name="zip" value="${event.eventZip}"><br>
-        <button type="button" id="event-edit-form-submit-${event.id}">Update Event</button>
-        <button type="button" id="event-edit-form-cancel-${event.id}">Cancel</button>
+        <input type="text" id="event-edit-form-zip-${eventId}" name="zip" value="${zip}"><br>
+        <button type="button" id="event-edit-form-submit-${eventId}">Update Event</button>
+        <button type="button" id="event-edit-form-cancel-${eventId}">Cancel</button>
     `
 }
 

--- a/src/scripts/events/EventEditForm.js
+++ b/src/scripts/events/EventEditForm.js
@@ -1,0 +1,77 @@
+import { editEvent } from './EventsProvider.js'
+
+//render the event edit form
+export const EventEditForm = (event) => {
+    return `
+        <label for="title">Title:</label><br>
+        <input type="text" id="event-edit-form-title-${event.id}" name="title" value="${event.name}"><br>
+        <label for="date">Date:</label><br>
+        <input type="date" id="event-edit-form-date-${event.id}" name="date" value="${event.startDate}"><br>
+        <label for="city">City:</label><br>
+        <input type="text" id="event-edit-form-city-${event.id}" name="city" value="${event.eventCity}"><br>
+        <label for="state">State:</label><br>
+        <input type="text" id="event-edit-form-state-${event.id}" name="state" value="${event.eventState}"><br>
+        <label for="zip">Zipcode:</label><br>
+        <input type="text" id="event-edit-form-zip-${event.id}" name="zip" value="${event.eventZip}"><br>
+        <button type="button" id="event-edit-form-submit-${event.id}">Update Event</button>
+        <button type="button" id="event-edit-form-cancel-${event.id}">Cancel</button>
+    `
+}
+
+//listen for click event
+const eventHub = document.querySelector('.container')
+eventHub.addEventListener('click', event => {
+    //check if edit button was clicked
+    if(event.target.id.startsWith("event-edit-form-submit-")){
+        //get event id
+        const [prefix, edit, form, submit, eventId] = event.target.id.split('-')
+
+        //get submitted values from form
+        const name = document.querySelector(`#event-edit-form-title-${eventId}`).value
+        const date = document.querySelector(`#event-edit-form-date-${eventId}`).value
+        const city = document.querySelector(`#event-edit-form-city-${eventId}`).value
+        const state = document.querySelector(`#event-edit-form-state-${eventId}`).value
+        const zip = document.querySelector(`#event-edit-form-zip-${eventId}`).value
+
+        //check that all fields have been filled in
+        if(name !== "" && date !== "" && city !== "" && state !== "" && zip !== "")
+        {
+            //get the current user
+            const userId = sessionStorage.getItem("activeUser")
+
+            //get the current date in miliseconds
+            const currentDate = new Date()
+            const currentDateMil = currentDate.getTime()
+
+            //create an event with submitted values
+            const newEvent = {
+                "userId": parseInt(userId),
+                "name": name,
+                "startDate": date,
+                "eventCity": city,
+                "eventState": state,
+                "eventZip": zip,
+                "dateAdded": currentDateMil,
+                "id": parseInt(eventId)
+            }
+            //edit the event
+            editEvent(newEvent)
+        }
+        //if any of the fields haven't been filled, show a window alert
+        else{
+            window.alert("Please fill out all fields")
+        }
+    }
+    else if(event.target.id.startsWith('event-edit-form-cancel-')){
+        //get event id
+        const [prefix, edit, form, cancel, eventId] = event.target.id.split('-')
+
+        //get event card and event edit form
+        const eventCard = document.querySelector(`.event-card-${eventId}`)
+        const editForm = document.querySelector(`#event-edit-form-${eventId}`)
+
+        //hide editForm and display eventCard
+        eventCard.classList.remove('no-display')
+        editForm.classList.add('no-display')
+    }
+})

--- a/src/scripts/events/EventWeather.js
+++ b/src/scripts/events/EventWeather.js
@@ -17,7 +17,7 @@ export const EventWeather = (events) => {
                 const temp = useEventWeather()
                 const eventCard = document.getElementById(`${event.startDate}--${event.id}`)
                 eventCard.innerHTML += `<button type="button" id="event-weather-btn-${event.id}">Show Weather</button>
-                                        <div class="event-weather-container hidden" id="event-weather-${event.id}">${temp}&#730;F</div>
+                                        <div class="event-weather-container no-display" id="event-weather-${event.id}">${temp}&#730;F</div>
                 `
             })
         }
@@ -28,7 +28,7 @@ export const EventWeather = (events) => {
                 const temp = useEventCurrentWeather()
                 const eventCard = document.getElementById(`${event.startDate}--${event.id}`)
                 eventCard.innerHTML += `<button type="button" id="event-weather-btn-${event.id}">Show Weather</button>
-                                    <div class="event-weather-container hidden" id="event-weather-${event.id}">Unable to show weather of date.  Current Weather: ${temp}&#730;F</div>
+                                    <div class="event-weather-container no-display" id="event-weather-${event.id}">Unable to show weather of date.  Current Weather: ${temp}&#730;F</div>
                 `
             })
         }

--- a/src/scripts/events/EventWeather.js
+++ b/src/scripts/events/EventWeather.js
@@ -8,8 +8,8 @@ export const EventWeather = (events) => {
         const eventDate = Math.floor(Date.parse(event.startDate) / (1000*60*60*24))
         const currentDate = new Date()
         const currentDateDays = Math.floor(currentDate.getTime()/ (1000*60*60*24))
-        //check that the event date is within 5 days of the current date
-        if(eventDate - currentDateDays <= 5){
+        //check that the event date is within 5 days of the current date and not in the past
+        if(eventDate - currentDateDays <= 5 && eventDate - currentDate >= 0){
             //if the event is within 5 days, get the temperature for that day
             getEventWeather(event)
             .then(_ => {

--- a/src/scripts/events/EventWeather.js
+++ b/src/scripts/events/EventWeather.js
@@ -9,7 +9,7 @@ export const EventWeather = (events) => {
         const currentDate = new Date()
         const currentDateDays = Math.floor(currentDate.getTime()/ (1000*60*60*24))
         //check that the event date is within 5 days of the current date and not in the past
-        if(eventDate - currentDateDays <= 5 && eventDate - currentDate >= 0){
+        if(eventDate - currentDateDays <= 5 && eventDate - currentDateDays >= 0){
             //if the event is within 5 days, get the temperature for that day
             getEventWeather(event)
             .then(_ => {

--- a/src/scripts/events/EventsList.js
+++ b/src/scripts/events/EventsList.js
@@ -19,6 +19,7 @@ const render = () => {
                 return Event(event)
             }).sort().join("")}
         `
+        //add next-event class to next chronological event
         const nextEvent = document.querySelector(".event-card")
         if(nextEvent){
             nextEvent.classList.add("next-event")

--- a/src/scripts/events/EventsProvider.js
+++ b/src/scripts/events/EventsProvider.js
@@ -98,3 +98,16 @@ export const useEventCurrentWeather = () => {
 export const useEventWeather = () => {
     return temp
 }
+
+//edit a given event, update the events array, and dispatch custom event
+export const editEvent = (event) => {
+    return fetch(`http://localhost:8088/events/${event.id}`, {
+        method: "PUT",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify(event)
+    })
+    .then(getEvents)
+    .then(dispatchEventChangeEvent)
+}

--- a/src/styles/events.css
+++ b/src/styles/events.css
@@ -5,3 +5,7 @@
 .next-event h3 {
     font-size: 1.5em;
 }
+
+.no-display {
+    display: none;
+}


### PR DESCRIPTION
# Description
The user can now edit their events.  They should be able to click the edit event button for each event and update the event info.  Only one event should be able to be edited at a time.  The weather should update if the location is changed.
Fixes # (issue)
## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
# Testing Instructions
- Try editing an event and make sure the information updates correctly
- After the event editing form is open, try editing another event and make sure you can only edit one
- Try to cancel an edit and make sure the edit form closes and the even was not updated
- Try inputing information to into an edit form, but before clicking the update event button either cancel or switch to editing another event.  Make sure that when the editing form is opened again for that same event, that the default values are the current event values, not what you inputed earlier
- Make sure that the delete and weather buttons still work as expected
- Make sure that users can still only add and see their own events
# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
