### PR TITLE
Bl friends events

### DIFF
--- a/src/scripts/events/Event.js
+++ b/src/scripts/events/Event.js
@@ -10,6 +10,8 @@ export const Event = (event) => {
             <div id="event-location-${event.id}">Location: ${event.eventCity}, ${event.eventState} ${event.eventZip}</div>
             <button type="button" id="delete-event-${event.id}">Delete</button>
             <button type="button" id="edit-event-${event.id}">Edit</button>
+            <button type="button" id="event-weather-btn-${event.id}">Show Weather</button>
+            <div class="event-weather-container no-display" id="event-weather-${event.id}"></div>
         </div>
         <form id="event-edit-form-${event.id}" class="event-edit-form no-display">
         </form>

--- a/src/scripts/events/EventWeather.js
+++ b/src/scripts/events/EventWeather.js
@@ -15,10 +15,8 @@ export const EventWeather = (events) => {
             .then(_ => {
                 //render the weather using the fetched temperature
                 const temp = useEventWeather()
-                const eventCard = document.getElementById(`${event.startDate}--${event.id}`)
-                eventCard.innerHTML += `<button type="button" id="event-weather-btn-${event.id}">Show Weather</button>
-                                        <div class="event-weather-container no-display" id="event-weather-${event.id}">${temp}&#730;F</div>
-                `
+                const eventWeather = document.getElementById(`event-weather-${event.id}`)
+                eventWeather.innerHTML = `${temp}&#730;F`
             })
         }
         //if the event is not within 5 days get its current temp
@@ -26,10 +24,8 @@ export const EventWeather = (events) => {
             getEventCurrentWeather(event)
             .then(_ => {
                 const temp = useEventCurrentWeather()
-                const eventCard = document.getElementById(`${event.startDate}--${event.id}`)
-                eventCard.innerHTML += `<button type="button" id="event-weather-btn-${event.id}">Show Weather</button>
-                                    <div class="event-weather-container no-display" id="event-weather-${event.id}">Unable to show weather of date.  Current Weather: ${temp}&#730;F</div>
-                `
+                const eventWeather = document.getElementById(`event-weather-${event.id}`)
+                eventWeather.innerHTML = `Cannot display of temperature at this date.  Current temp: ${temp}&#730;F`
             })
         }
     })

--- a/src/scripts/events/EventsList.js
+++ b/src/scripts/events/EventsList.js
@@ -60,3 +60,9 @@ eventHub.addEventListener('eventStateChanged', event => {
     //render the eventlist
     render()
 })
+
+//listen for if the friend state has changed
+eventHub.addEventListener('friendStateChanged', event => {
+    //render the friends event list
+    FriendEventsList()
+})

--- a/src/scripts/events/EventsList.js
+++ b/src/scripts/events/EventsList.js
@@ -2,6 +2,7 @@ import { getEvents, useEvents } from './EventsProvider.js'
 import { Event } from './Event.js'
 import { EventForm } from './EventForm.js'
 import { EventWeather } from './EventWeather.js'
+import { FriendEventsList } from './FriendEventsList.js'
 
 const dashboard = document.querySelector('.dashboard')
 
@@ -40,10 +41,14 @@ export const EventList = () => {
             </form>
             <div class="events-list">
             </div>
+            <div class="friends-events-list">
+            </div>
         </div>
     `
     //render the eventForm
     EventForm();
+    //render the list of friends events
+    FriendEventsList()
     //render the event list
     render()
 }

--- a/src/scripts/events/EventsProvider.js
+++ b/src/scripts/events/EventsProvider.js
@@ -9,8 +9,8 @@ let temp = 0
 let currentTemp = 0
 //variable to store friends events
 let friendsEvents = []
-//variable to hold users
-let users = []
+//variable that holds events with expanded users
+let expandedEvents = []
 
 //fetch events from the database using the current userId
 export const getEvents = () => {
@@ -117,26 +117,24 @@ export const editEvent = (event) => {
     .then(dispatchEventChangeEvent)
 }
 
-//fetch array of current users friends events
+//get array of current users friends events
 export const getFriendsEvents = () => {
-    return fetch(`http://localhost:8088/users?_embed=events&_embed=friends`)
+    //fetch events with expanded users
+    return fetch(`http://localhost:8088/events?_expand=user`)
     .then(response => response.json())
     .then(parsedResponse => {
-        users = parsedResponse
+        expandedEvents = parsedResponse
     })
+    //get the friends of the current user
     .then(getFriends)
     .then(_ => {
-        debugger;
+        //get all the friends ids of the current user
         const friendsIds = useFriends().map(friend => {
             return friend.userId
         })
-        const friendsUsers = users.filter(user => {
-            return friendsIds.includes(user.id)
-        })
-        friendsUsers.forEach(user => {
-            user.events.forEach(event => {
-                friendsEvents.push(event)
-            })
+        //filter out events that do not belong to a friend
+        friendsEvents = expandedEvents.filter(event => {
+            return friendsIds.includes(event.userId)
         })
     })
 }

--- a/src/scripts/events/EventsProvider.js
+++ b/src/scripts/events/EventsProvider.js
@@ -1,4 +1,5 @@
 import defaultExport from "../Settings.js"
+import { getFriends, useFriends } from '../friends/FriendProvider.js'
 
 //variable that holds the events
 let events = []
@@ -6,6 +7,10 @@ let events = []
 let temp = 0
 //variable to hold current temp at an event location
 let currentTemp = 0
+//variable to store friends events
+let friendsEvents = []
+//variable to hold users
+let users = []
 
 //fetch events from the database using the current userId
 export const getEvents = () => {
@@ -110,4 +115,34 @@ export const editEvent = (event) => {
     })
     .then(getEvents)
     .then(dispatchEventChangeEvent)
+}
+
+//fetch array of current users friends events
+export const getFriendsEvents = () => {
+    return fetch(`http://localhost:8088/users?_embed=events&_embed=friends`)
+    .then(response => response.json())
+    .then(parsedResponse => {
+        users = parsedResponse
+    })
+    .then(getFriends)
+    .then(_ => {
+        debugger;
+        const friendsIds = useFriends().map(friend => {
+            return friend.userId
+        })
+        const friendsUsers = users.filter(user => {
+            return friendsIds.includes(user.id)
+        })
+        friendsUsers.forEach(user => {
+            user.events.forEach(event => {
+                friendsEvents.push(event)
+            })
+        })
+    })
+}
+
+
+//return copy of friendsEvents
+export const useFriendsEvents = () => {
+    return friendsEvents.slice()
 }

--- a/src/scripts/events/FriendEvent.js
+++ b/src/scripts/events/FriendEvent.js
@@ -7,6 +7,8 @@ export const FriendEvent = (event) => {
             <h4 id="event-owner-${event.id}">Owner: ${event.user.username}</h4>
             <div id="event-date-${event.id}">Date: ${event.startDate}</div>
             <div id="event-location-${event.id}">Location: ${event.eventCity}, ${event.eventState} ${event.eventZip}</div>
+            <button type="button" id="event-weather-btn-${event.id}">Show Weather</button>
+            <div class="event-weather-container no-display" id="event-weather-${event.id}"></div>
         </div>
     `
 }

--- a/src/scripts/events/FriendEvent.js
+++ b/src/scripts/events/FriendEvent.js
@@ -2,10 +2,12 @@
 //return html for a friend event
 export const FriendEvent = (event) => {
     return `
-    <div id="${event.startDate}--${event.id}" class="event-card event-card-${event.id}">
-        <h3 id="event-name-${event.id}">${event.name}</h3>
-        <div id="event-date-${event.id}">Date: ${event.startDate}</div>
-        <div id="event-location-${event.id}">Location: ${event.eventCity}, ${event.eventState} ${event.eventZip}</div>
-    </div>
+        <div id="${event.startDate}--${event.id}" class="event-card event-card-${event.id}">
+            <h3 id="event-name-${event.id}">${event.name}</h3>
+            <h4 id="event-owner-${event.id}">Owner:${event.user.username}</h4>
+            <div id="event-date-${event.id}">Date: ${event.startDate}</div>
+            <div id="event-location-${event.id}">Location: ${event.eventCity}, ${event.eventState} ${event.eventZip}</div>
+        </div>
     `
+
 }

--- a/src/scripts/events/FriendEvent.js
+++ b/src/scripts/events/FriendEvent.js
@@ -4,10 +4,9 @@ export const FriendEvent = (event) => {
     return `
         <div id="${event.startDate}--${event.id}" class="event-card event-card-${event.id}">
             <h3 id="event-name-${event.id}">${event.name}</h3>
-            <h4 id="event-owner-${event.id}">Owner:${event.user.username}</h4>
+            <h4 id="event-owner-${event.id}">Owner: ${event.user.username}</h4>
             <div id="event-date-${event.id}">Date: ${event.startDate}</div>
             <div id="event-location-${event.id}">Location: ${event.eventCity}, ${event.eventState} ${event.eventZip}</div>
         </div>
     `
-
 }

--- a/src/scripts/events/FriendEvent.js
+++ b/src/scripts/events/FriendEvent.js
@@ -1,0 +1,11 @@
+
+//return html for a friend event
+export const FriendEvent = (event) => {
+    return `
+    <div id="${event.startDate}--${event.id}" class="event-card event-card-${event.id}">
+        <h3 id="event-name-${event.id}">${event.name}</h3>
+        <div id="event-date-${event.id}">Date: ${event.startDate}</div>
+        <div id="event-location-${event.id}">Location: ${event.eventCity}, ${event.eventState} ${event.eventZip}</div>
+    </div>
+    `
+}

--- a/src/scripts/events/FriendEventsList.js
+++ b/src/scripts/events/FriendEventsList.js
@@ -1,5 +1,6 @@
 import { FriendEvent } from './FriendEvent.js'
 import { getFriendsEvents, useFriendsEvents } from './EventsProvider.js'
+import { EventWeather } from './EventWeather.js'
 
 export const FriendEventsList = () => {
     //get the events of the users friends
@@ -14,7 +15,9 @@ export const FriendEventsList = () => {
             <h3>Friends Events</h3>
             ${friendsEvents.map(event => {
                 return FriendEvent(event)
-            })}
+            }).sort().join("")}
         `
+        //render weather for the friends events
+        EventWeather(friendsEvents)
     })
 }

--- a/src/scripts/events/FriendEventsList.js
+++ b/src/scripts/events/FriendEventsList.js
@@ -1,0 +1,10 @@
+import { FriendEvent } from './FriendEvent.js'
+import { getFriendsEvents, useFriendsEvents } from './EventsProvider.js'
+
+export const FriendEventsList = () => {
+    getFriendsEvents()
+    .then(_ => {
+        const friendsEvents = useFriendsEvents()
+        debugger;
+    })
+}

--- a/src/scripts/events/FriendEventsList.js
+++ b/src/scripts/events/FriendEventsList.js
@@ -5,6 +5,12 @@ export const FriendEventsList = () => {
     getFriendsEvents()
     .then(_ => {
         const friendsEvents = useFriendsEvents()
-        debugger;
+        const contentTarget = document.querySelector('.friends-events-list')
+        contentTarget.innerHTML = `
+            <h3>Friends Events</h3>
+            ${friendsEvents.map(event => {
+                return FriendEvent(event)
+            })}
+        `
     })
 }

--- a/src/scripts/events/FriendEventsList.js
+++ b/src/scripts/events/FriendEventsList.js
@@ -2,10 +2,14 @@ import { FriendEvent } from './FriendEvent.js'
 import { getFriendsEvents, useFriendsEvents } from './EventsProvider.js'
 
 export const FriendEventsList = () => {
+    //get the events of the users friends
     getFriendsEvents()
     .then(_ => {
         const friendsEvents = useFriendsEvents()
+
+        //set render the friends events list
         const contentTarget = document.querySelector('.friends-events-list')
+        //for each event, create the HTML for that event using FriendEvent()
         contentTarget.innerHTML = `
             <h3>Friends Events</h3>
             ${friendsEvents.map(event => {


### PR DESCRIPTION
# Description
The user should now be able to see the events of their friends listed.  Each friend event should include the username of the friend and the user should not be able to edit or delete a friend event.
Fixes # (issue)
## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)
# Testing Instructions
- Login with a user that has friends and make sure that they can see the events of those friends
- Login with a user with no friends and make sure that they see no events under friends events
- Add a friend and make sure that the events of that friend are now displayed
- Remove a friend and make sure that the events of that friend are no longer displayed
- Add an event to a friend of the user and check that when the user logs back in that they see that new event
- Remove an event from a friend of the user and check that when the user logs back in that they no longer see that event
- Adding or removing a friend should immediately re-render the friends events list
# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
