### PR TITLE
articles re-render on friend changes

### DIFF
--- a/src/scripts/articles/ArticleList.js
+++ b/src/scripts/articles/ArticleList.js
@@ -194,3 +194,29 @@ export const renderFriendArticles = (articleArray) => {
     //places article HTML list in content location
     articleFriendTarget.innerHTML = articleFriendListHTML
 }
+
+//eventHub for outside events
+const eventHub2 = document.querySelector(".container")
+
+//rerenders friend articles when add/delete
+eventHub2.addEventListener("friendStateChanged", event => {
+    // Friend State updated, refresh friends
+    getFriends() // fetch all of the current user's friends
+    .then(useFriends)
+    .then(() => {
+        const friends = useFriends()
+        if(friends.length !== 0){
+            //gets articles from your friends
+            getFriendArticles(friends)
+            .then(()=> {
+                const articles = useFriendArticles()
+                renderFriendArticles(articles)
+            })
+        }
+        //erases the remaining articles if you have no friends
+        else{
+            const articleFriendTarget = document.querySelector(".friend-articles-list")
+            articleFriendTarget.innerHTML = ""
+        }
+    })
+})


### PR DESCRIPTION
# Description
Articles now refresh when a friend is added/deleted
## Type of change
- [x] New feature (non-breaking change which adds functionality)
# Testing Instructions
Add/remove articles as multiple users who are/aren't friends
add/delete friends to verify that proper articles appear/disappear
# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
